### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,10 +24,10 @@ subprojects {
 
   repositories {
     mavenCentral(artifactUrls: [
-        "http://maven.springframework.org/release",
-        "http://maven.springframework.org/milestone",
-        //"http://repository.jboss.org/maven2/",
-        //"http://download.java.net/maven/2/"
+        "https://maven.springframework.org/release",
+        "https://maven.springframework.org/milestone",
+        //"https://repository.jboss.org/maven2/",
+        //"https://download.java.net/maven/2/"
     ])
     mavenLocal()
   }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://download.java.net/maven/2/ (301) migrated to:  
  https://download.java.net/maven/2/ ([https](https://download.java.net/maven/2/) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://repository.jboss.org/maven2/ migrated to:  
  https://repository.jboss.org/maven2/ ([https](https://repository.jboss.org/maven2/) result 200).
* http://maven.springframework.org/milestone migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* http://maven.springframework.org/release migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result 302).