### PR TITLE
URL Cleanup

### DIFF
--- a/doc/api/REST.html
+++ b/doc/api/REST.html
@@ -23,7 +23,7 @@ class Account {
 
 <h3>Discoverability</h3>
 
-Following the principles of [HATEOS](http://en.wikipedia.org/wiki/HATEOAS), the REST API should be fundamentally discoverable, starting with the base URL:
+Following the principles of [HATEOS](https://en.wikipedia.org/wiki/HATEOAS), the REST API should be fundamentally discoverable, starting with the base URL:
 
 <pre><code>curl -v http://localhost:8080/baseurl/
 </code></pre>
@@ -59,7 +59,7 @@ Server: Spring Data Services Web Exporter/1.0.0.BUILD-SNAPSHOT
 
 <h3>Links</h3>
 
-The method for exposing links here is somewhat arbitrary since there's no real consenus on how this should be done in JSON. The DOJO framework has [some linking functionality](http://www.sitepen.com/blog/2008/06/17/json-referencing-in-dojo/) that uses "$ref" as a field name, which corresponds to what MongoDB documents use for DBRefs. This convention seems as good as any other, so is the one we'll be using here.
+The method for exposing links here is somewhat arbitrary since there's no real consenus on how this should be done in JSON. The DOJO framework has [some linking functionality](https://www.sitepen.com/blog/2008/06/17/json-referencing-in-dojo/) that uses "$ref" as a field name, which corresponds to what MongoDB documents use for DBRefs. This convention seems as good as any other, so is the one we'll be using here.
 
 If the server understands links on the entity (meaning it's a JPA Entity with a @OneTo... et al mapping), then the user could POST new associations directly inline in the parent JSON:
 

--- a/doc/api/REST.md
+++ b/doc/api/REST.md
@@ -22,7 +22,7 @@ Here's what some sample resources would look like on the server side as a JPA en
 
 ### Discoverability
 
-Following the principles of [HATEOS](http://en.wikipedia.org/wiki/HATEOAS), the REST API should be fundamentally discoverable, starting with the base URL:
+Following the principles of [HATEOS](https://en.wikipedia.org/wiki/HATEOAS), the REST API should be fundamentally discoverable, starting with the base URL:
 
     curl -v http://localhost:8080/baseurl/
 
@@ -55,7 +55,7 @@ Specifying an Accept header should cause the output to be rendered in the repres
 
 ### Links
 
-The method for exposing links here is somewhat arbitrary since there's no real consenus on how this should be done in JSON. The DOJO framework has [some linking functionality](http://www.sitepen.com/blog/2008/06/17/json-referencing-in-dojo/) that uses "$ref" as a field name, which corresponds to what MongoDB documents use for DBRefs. This convention seems as good as any other, so is the one we'll be using here.
+The method for exposing links here is somewhat arbitrary since there's no real consenus on how this should be done in JSON. The DOJO framework has [some linking functionality](https://www.sitepen.com/blog/2008/06/17/json-referencing-in-dojo/) that uses "$ref" as a field name, which corresponds to what MongoDB documents use for DBRefs. This convention seems as good as any other, so is the one we'll be using here.
 
 If the server understands links on the entity (meaning it's a JPA Entity with a @OneTo... et al mapping), then the user could POST new associations directly inline in the parent JSON:
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://en.wikipedia.org/wiki/HATEOAS with 2 occurrences migrated to:  
  https://en.wikipedia.org/wiki/HATEOAS ([https](https://en.wikipedia.org/wiki/HATEOAS) result 200).
* [ ] http://www.sitepen.com/blog/2008/06/17/json-referencing-in-dojo/ with 2 occurrences migrated to:  
  https://www.sitepen.com/blog/2008/06/17/json-referencing-in-dojo/ ([https](https://www.sitepen.com/blog/2008/06/17/json-referencing-in-dojo/) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/base with 1 occurrences
* http://localhost:8080/baseUrl with 2 occurrences
* http://localhost:8080/baseUrl/resource/1 with 2 occurrences
* http://localhost:8080/baseurl/ with 4 occurrences
* http://localhost:8080/baseurl/account/ with 2 occurrences
* http://localhost:8080/baseurl/account/1 with 8 occurrences
* http://localhost:8080/baseurl/account/2 with 2 occurrences
* http://localhost:8080/baseurl/person/ with 2 occurrences
* http://localhost:8080/baseurl/person/1 with 4 occurrences
* http://localhost:8080/baseurl/person/1?p=accounts with 2 occurrences
* http://localhost:8080/baseurl/person/2 with 2 occurrences
* http://localhost:8080/baseurl/person/3 with 2 occurrences
* http://localhost:8080/baseurl/service1/ with 4 occurrences
* http://localhost:8080/baseurl/service2/ with 4 occurrences
* http://localhost:8080/baseurl/service3/ with 4 occurrences
* http://localhost:8080/data/ with 1 occurrences
* http://localhost:8080/data/person with 1 occurrences
* http://www.w3.org/1999/xhtml with 1 occurrences